### PR TITLE
Add config flag for prepending I prefix to autogen'd interfaces

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ publishArtifact in Test := false
 
 lazy val root = (project in file(".")).
   settings(
-    version in ThisBuild := "0.4.3",
+    version in ThisBuild := "0.4.4",
     organization in ThisBuild := "com.returntocorp",
     description := "Generate TS models from scala",
     name := "scala-ts",

--- a/src/main/scala/com/mpc/scalats/configuration/Config.scala
+++ b/src/main/scala/com/mpc/scalats/configuration/Config.scala
@@ -10,5 +10,6 @@ case class Config(
                  emitClasses: Boolean = false,
                  optionToNullable: Boolean = true,
                  optionToUndefined: Boolean = false,
-                 outputStream : Option[PrintStream] = None
+                 outputStream : Option[PrintStream] = None,
+                 prependIPrefix: Boolean = true
                  )

--- a/src/main/scala/com/mpc/scalats/configuration/Config.scala
+++ b/src/main/scala/com/mpc/scalats/configuration/Config.scala
@@ -6,10 +6,10 @@ import java.io.PrintStream
   * Created by Milosz on 09.12.2016.
   */
 case class Config(
-                 emitInterfaces: Boolean = true,
-                 emitClasses: Boolean = false,
-                 optionToNullable: Boolean = true,
-                 optionToUndefined: Boolean = false,
-                 outputStream : Option[PrintStream] = None,
-                 prependIPrefix: Boolean = true
-                 )
+    emitInterfaces: Boolean = true,
+    emitClasses: Boolean = false,
+    optionToNullable: Boolean = true,
+    optionToUndefined: Boolean = false,
+    outputStream: Option[PrintStream] = None,
+    prependIPrefix: Boolean = true
+)

--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -1,22 +1,31 @@
 package com.mpc.scalats.core
 
 import com.mpc.scalats.configuration.Config
-import com.mpc.scalats.core.ScalaModel.CaseClassRef
-import com.mpc.scalats.core.TypeScriptModel.{ClassConstructor, ClassConstructorParameter, NullRef, UndefinedRef}
+import com.mpc.scalats.core.TypeScriptModel.{
+  ClassConstructor,
+  ClassConstructorParameter,
+  NullRef,
+  UndefinedRef
+}
 
 /**
   * Created by Milosz on 09.06.2016.
   */
 object Compiler {
-  def compile(scalaClasses: List[ScalaModel.Entity])(implicit config: Config): List[TypeScriptModel.Declaration] = {
+  def compile(scalaClasses: List[ScalaModel.Entity])(
+      implicit config: Config): List[TypeScriptModel.Declaration] = {
     scalaClasses flatMap { scalaClass =>
-      val interface = if (config.emitInterfaces) List(compileInterface(scalaClass)) else List.empty
-      val clazz = if (config.emitClasses) List(compileClass(scalaClass)) else List.empty
+      val interface =
+        if (config.emitInterfaces) List(compileInterface(scalaClass))
+        else List.empty
+      val clazz =
+        if (config.emitClasses) List(compileClass(scalaClass)) else List.empty
       interface ++ clazz
     }
   }
 
-  private def compileInterface(scalaClass: ScalaModel.Entity)(implicit config: Config) = {
+  private def compileInterface(scalaClass: ScalaModel.Entity)(
+      implicit config: Config) = {
     TypeScriptModel.InterfaceDeclaration(
       buildInterfaceName(scalaClass.name),
       scalaClass.members.map { scalaMember =>
@@ -30,14 +39,12 @@ object Compiler {
   }
 
   private def buildInterfaceName(name: String)(implicit config: Config) = {
-    if (config.prependIPrefix) {
-      s"I$name"
-    } else {
-      name
-    }
+    val prefix = if (config.prependIPrefix) "I" else ""
+    s"${prefix}${name}"
   }
 
-  private def compileClass(scalaClass: ScalaModel.Entity)(implicit config: Config) = {
+  private def compileClass(scalaClass: ScalaModel.Entity)(
+      implicit config: Config) = {
     TypeScriptModel.ClassDeclaration(
       scalaClass.name,
       ClassConstructor(
@@ -55,10 +62,9 @@ object Compiler {
   }
 
   private def compileTypeRef(
-                              scalaTypeRef: ScalaModel.TypeRef,
-                              inInterfaceContext: Boolean
-                            )
-                            (implicit config: Config): TypeScriptModel.TypeRef = scalaTypeRef match {
+      scalaTypeRef: ScalaModel.TypeRef,
+      inInterfaceContext: Boolean
+  )(implicit config: Config): TypeScriptModel.TypeRef = scalaTypeRef match {
     case ScalaModel.IntRef =>
       TypeScriptModel.NumberRef
     case ScalaModel.LongRef =>
@@ -72,24 +78,35 @@ object Compiler {
     case ScalaModel.SeqRef(innerType) =>
       TypeScriptModel.ArrayRef(compileTypeRef(innerType, inInterfaceContext))
     case ScalaModel.CaseClassRef(name, typeArgs) =>
-      val actualName = if (inInterfaceContext) buildInterfaceName(name) else name
-      TypeScriptModel.CustomTypeRef(actualName, typeArgs.map(compileTypeRef(_, inInterfaceContext)))
+      val actualName =
+        if (inInterfaceContext) buildInterfaceName(name) else name
+      TypeScriptModel.CustomTypeRef(
+        actualName,
+        typeArgs.map(compileTypeRef(_, inInterfaceContext)))
     case ScalaModel.DateRef =>
       TypeScriptModel.DateRef
     case ScalaModel.DateTimeRef =>
       TypeScriptModel.DateTimeRef
     case ScalaModel.TypeParamRef(name) =>
       TypeScriptModel.TypeParamRef(name)
-    case ScalaModel.OptionRef(innerType) if config.optionToNullable && config.optionToUndefined =>
-      TypeScriptModel.UnionType(TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), NullRef), UndefinedRef)
+    case ScalaModel.OptionRef(innerType)
+        if config.optionToNullable && config.optionToUndefined =>
+      TypeScriptModel.UnionType(
+        TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                  NullRef),
+        UndefinedRef)
     case ScalaModel.OptionRef(innerType) if config.optionToNullable =>
-      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), NullRef)
+      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                NullRef)
     case ScalaModel.MapRef(kT, vT) =>
-      TypeScriptModel.MapType(compileTypeRef(kT, inInterfaceContext), compileTypeRef(vT, inInterfaceContext))
+      TypeScriptModel.MapType(compileTypeRef(kT, inInterfaceContext),
+                              compileTypeRef(vT, inInterfaceContext))
     case ScalaModel.UnionRef(i, i2) =>
-      TypeScriptModel.UnionType(compileTypeRef(i, inInterfaceContext), compileTypeRef(i2, inInterfaceContext))
+      TypeScriptModel.UnionType(compileTypeRef(i, inInterfaceContext),
+                                compileTypeRef(i2, inInterfaceContext))
     case ScalaModel.OptionRef(innerType) if config.optionToUndefined =>
-      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), UndefinedRef)
+      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                UndefinedRef)
     case ScalaModel.UnknownTypeRef(_) =>
       TypeScriptModel.StringRef
   }

--- a/src/main/scala/com/mpc/scalats/sbt/TypeScriptGeneratorPlugin.scala
+++ b/src/main/scala/com/mpc/scalats/sbt/TypeScriptGeneratorPlugin.scala
@@ -16,9 +16,14 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
 
     val emitInterfaces = settingKey[Boolean]("Generate interface declarations")
     val emitClasses = settingKey[Boolean]("Generate class declarations")
-    val optionToNullable = settingKey[Boolean]("Option types will be compiled to 'type | null'")
-    val optionToUndefined = settingKey[Boolean]("Option types will be compiled to 'type | undefined'")
-    val outputFile  = settingKey[Option[PrintStream]]("Print stream to write. Defaults to Console.out")
+    val optionToNullable =
+      settingKey[Boolean]("Option types will be compiled to 'type | null'")
+    val optionToUndefined =
+      settingKey[Boolean]("Option types will be compiled to 'type | undefined'")
+    val outputFile = settingKey[Option[PrintStream]](
+      "Print stream to write. Defaults to Console.out")
+    val prependIPrefix =
+      settingKey[Boolean]("Whether to prefix interface names with I")
   }
 
   import autoImport._
@@ -30,7 +35,8 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
         (emitClasses in generateTypeScript).value,
         (optionToNullable in generateTypeScript).value,
         (optionToUndefined in generateTypeScript).value,
-        (outputFile in generateTypeScript).value
+        (outputFile in generateTypeScript).value,
+        (prependIPrefix in generateTypeScript).value
       )
 
       val args = spaceDelimited("").parsed
@@ -44,7 +50,8 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
     emitClasses in generateTypeScript := false,
     optionToNullable in generateTypeScript := true,
     optionToUndefined in generateTypeScript := false,
-    outputFile in generateTypeScript := None
+    outputFile in generateTypeScript := None,
+    prependIPrefix := false
   )
 
 }


### PR DESCRIPTION
This PR adds a configuration flag to either enable or disable the `I` prefix for interfaces, which allows scala-ts to conform to the different TypeScript interface naming opinions.