### PR TITLE
Fix base classes filtering

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
@@ -62,7 +62,7 @@ object ScalaParser {
       members.toList,
       typeParams,
       aType.baseClasses.map(_.name.toString).filter {
-        case name if !(thisClassName :+ unwantedBaseClasses).contains(name) => false
+        case name if (thisClassName +: unwantedBaseClasses).contains(name) => false
         case _ => true
       },
       aType.typeSymbol.asClass.isTrait


### PR DESCRIPTION
The previous filtering almost always returned except in some weird cases like for `case class Cat(...) extends C`